### PR TITLE
fix: fixes incomplete type for player api function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# This project uses yarn. Do not
+# include npm package lock.
+package-lock.json
+
 # Logs
 logs
 *.log

--- a/src/apis/PlayerApi.ts
+++ b/src/apis/PlayerApi.ts
@@ -48,7 +48,7 @@ export class PlayerApi {
    */
   getCurrentlyPlayingTrack(
     options?: GetCurrentlyPlayingTrackOptions,
-  ): Promise<CurrentlyPlaying> {
+  ): Promise<CurrentlyPlaying | string> {
     return this.http.get<CurrentlyPlaying>(
       '/me/player/currently-playing',
       options && { params: options },


### PR DESCRIPTION
`getCurrentlyPlayingTrack` returns an empty string if no song is currently
playing. The type response of that function is incorrect, leading to
complile errors. This PR fixes the issue by correcting the type
response.

Fixes #22