### PR TITLE
feat(spotifyaxios.ts): add spotify error message to axios error

### DIFF
--- a/src/helpers/spotifyAxios.spec.ts
+++ b/src/helpers/spotifyAxios.spec.ts
@@ -57,6 +57,24 @@ describe('spotifyAxios', () => {
     axiosMock.mockRejectedValue(testError);
     await expect(spotifyAxios('bar', 'GET', 'token')).rejects.toThrow('foo');
   });
+
+  it('should handle errors and the spotify error message', async () => {
+    const testError = {
+      message: 'foo',
+      response: {
+        data: {
+          error: {
+            status: 400,
+            message: 'Error message from Spotify',
+          },
+        },
+      },
+    };
+    axiosMock.mockRejectedValue(testError);
+    await expect(spotifyAxios('bar', 'GET', 'token')).rejects.toThrow(
+      'foo: Error message from Spotify',
+    );
+  });
 });
 
 describe('paramsSerializer', () => {

--- a/src/helpers/spotifyAxios.ts
+++ b/src/helpers/spotifyAxios.ts
@@ -27,6 +27,9 @@ export async function spotifyAxios<T>(
     return response.data as T;
   } catch (error) {
     const err = error as AxiosError;
+    if (error?.response?.data?.error?.message) {
+      throw new Error(`${err.message}: ${error.response.data.error.message}`);
+    }
     throw new Error(err.message);
   }
 }


### PR DESCRIPTION
When working with this library, I got a 400 bad request and it took me a while to troubleshoot the issue. This could save some time by including the error message returned by the spotify api.
In my case it was:

```
  data: {
    error: {
      status: 400,
      message: 'You can add a maximum of 100 tracks per request.'
    }
  }
```

Without this change, all I got in the console was:

```
Error: Request failed with status code 400
    at Object.<anonymous> ({project}/node_modules/spotify-web-api-ts/src/helpers/spotifyAxios.ts:30:11)
    at Generator.throw (<anonymous>)
    at rejected ({project}node_modules/spotify-web-api-ts/cjs/helpers/spotifyAxios.js:6:65)
```
And now:

````
Error: Request failed with status code 400: You can add a maximum of 100 tracks per request.
    at Object.<anonymous> ({project}node_modules/spotify-web-api-ts/src/helpers/spotifyAxios.ts:30:11)
    at Generator.throw (<anonymous>)
    at rejected ({project}/node_modules/spotify-web-api-ts/cjs/helpers/spotifyAxios.js:6:65)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```